### PR TITLE
fix: move redirect() to client side to avoid server-side errors

### DIFF
--- a/src/features/auth/components/SignInButton/SignInButton.tsx
+++ b/src/features/auth/components/SignInButton/SignInButton.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { redirect, RedirectType } from 'next/navigation';
 import { useCallback } from 'react';
 
 import { handleSignIn } from '../../server-actions';
@@ -10,7 +11,8 @@ type Props = {
 
 export function SignInButton({ className }: Props): React.JSX.Element {
   const handleSignInAction = useCallback(async () => {
-    await handleSignIn('cognito');
+    const redirectUrl = await handleSignIn('cognito');
+    redirect(redirectUrl, RedirectType.push);
   }, []);
 
   return (

--- a/src/features/auth/server-actions.ts
+++ b/src/features/auth/server-actions.ts
@@ -4,8 +4,9 @@ import type { ProviderId } from 'next-auth/providers';
 
 import { signIn, signOut } from './auth';
 
-export async function handleSignIn(providerId: ProviderId): Promise<void> {
-  await signIn(providerId);
+export async function handleSignIn(providerId: ProviderId): Promise<string> {
+  const redirectUrl = await signIn(providerId, { redirect: false }) as string;
+  return redirectUrl;
 }
 
 export async function handleSignOut(): Promise<void> {


### PR DESCRIPTION
## Summary

In `redirect()` behavior from Next.js documents:

> - In Server Actions and Route Handlers, redirect should be called outside the try block when using try/catch statements.
> - redirect throws an error so it should be called outside the try block when using try/catch statements.
> https://nextjs.org/docs/app/api-reference/functions/redirect#behavior

## References

- https://nextjs.org/docs/app/api-reference/functions/redirect#behavior
- [App Router x Auth.js 5 (Beta)でハマったことメモ #Next.js - Qiita](https://qiita.com/hkano2022/items/492c24ab747f40b1cefa#%E3%83%AA%E3%83%80%E3%82%A4%E3%83%AC%E3%82%AF%E3%83%88%E3%81%8C%E3%81%86%E3%81%BE%E3%81%8F%E5%8B%95%E3%81%8B%E3%81%AA%E3%81%84)