### PR TITLE
perf: cache S3 client to avoid repeated Cognito credential exchange

### DIFF
--- a/src/features/bucket/s3-client-instance.test.ts
+++ b/src/features/bucket/s3-client-instance.test.ts
@@ -48,6 +48,49 @@ describe('S3 Client Instance', () => {
     expect(client).toBeDefined();
   });
 
+  it('reuses the same client instance for the same ID token', async () => {
+    // Arrange
+    const { auth } = await import('../auth/auth');
+    const mockAuth = auth as unknown as jest.MockedFunction<() => Promise<Session | null>>;
+    mockAuth.mockResolvedValue({
+      user: { email: 'test@example.com' },
+      token: 'valid-id-token',
+      expires: '2099-01-01',
+    });
+
+    // Act
+    const { getS3Client } = await import('./s3-client-instance');
+    const first = await getS3Client();
+    const second = await getS3Client();
+
+    // Assert
+    expect(second).toBe(first);
+  });
+
+  it('creates a new client instance when the ID token changes', async () => {
+    // Arrange
+    const { auth } = await import('../auth/auth');
+    const mockAuth = auth as unknown as jest.MockedFunction<() => Promise<Session | null>>;
+    mockAuth.mockResolvedValueOnce({
+      user: { email: 'test@example.com' },
+      token: 'first-token',
+      expires: '2099-01-01',
+    });
+    mockAuth.mockResolvedValueOnce({
+      user: { email: 'test@example.com' },
+      token: 'second-token',
+      expires: '2099-01-01',
+    });
+
+    // Act
+    const { getS3Client } = await import('./s3-client-instance');
+    const first = await getS3Client();
+    const second = await getS3Client();
+
+    // Assert
+    expect(second).not.toBe(first);
+  });
+
   it('should throw error if idToken is missing', async () => {
     // Arrange
     const { auth } = await import('../auth/auth');

--- a/src/features/bucket/s3-client-instance.ts
+++ b/src/features/bucket/s3-client-instance.ts
@@ -23,6 +23,13 @@ if (region == null || region === '') {
 
 const providerName = `cognito-idp.${region}.amazonaws.com/${userPoolId}`;
 
+// fromCognitoIdentityPool memoizes credentials until they expire while the provider instance lives.
+// Building a new S3Client per request re-ran the Cognito exchange every time, twice per request
+// since both presigning and listing call getS3Client. Caching the client by ID token collapses
+// that to one exchange per token. A single entry avoids the stale-token buildup a Map would cause.
+// A different token just rebuilds, which matches the previous unconditional behavior.
+let cachedClient: { token: string; client: S3Client } | null = null;
+
 export async function getS3Client(): Promise<S3Client> {
   const session = await auth();
 
@@ -30,7 +37,11 @@ export async function getS3Client(): Promise<S3Client> {
     throw new Error('No authenticated session or ID token available');
   }
 
-  return new S3Client({
+  if (cachedClient != null && cachedClient.token === session.token) {
+    return cachedClient.client;
+  }
+
+  const client = new S3Client({
     region,
     credentials: fromCognitoIdentityPool({
       identityPoolId,
@@ -40,4 +51,8 @@ export async function getS3Client(): Promise<S3Client> {
       },
     }),
   });
+
+  cachedClient = { token: session.token, client };
+
+  return client;
 }


### PR DESCRIPTION
## Summary

The authenticated image list felt slow to load, so I measured it with Chrome DevTools. Largest Contentful Paint was dominated by resource load delay (86% locally, 94% in production), not by image transfer. The S3 objects themselves download in under 20ms. The real wait is the `/api/images` response that produces the presigned URLs, which took about 800ms locally and 2.4 to 2.9s in production. Until that response returns, the browser cannot discover a single image URL to request.

The cost lives in credential resolution. `getS3Client` built a fresh `S3Client` with a new `fromCognitoIdentityPool` provider on every call, and the request path calls it twice, once for presigning and once for listing. Each fresh provider re-runs the Cognito Identity Pool exchange. `fromCognitoIdentityPool` memoizes the exchanged credentials for the lifetime of the provider instance, so this change reuses the client keyed by the session ID token. Within a warm instance the exchange now happens once per token instead of on every request. A single entry is enough here and avoids a Map accumulating stale tokens, and a different token simply rebuilds the client.

This does not address two separate factors. Cold starts still pay one exchange. Production also runs the function in `iad1` while Cognito and S3 are in `ap-northeast-1`, so each cross-region round trip is expensive. Moving the function region is a follow-up.

## Test plan

- [x] `npx jest src/features/bucket` (8 tests pass). Added cases cover client reuse for the same ID token and rebuild when the token changes.
- [x] `npx tsc --noEmit`
- [x] `npx eslint` on the changed files
