### PR TITLE
perf: dedup auth() and pin AWS-facing functions to Tokyo region

### DIFF
--- a/src/app/api/images/delete/route.ts
+++ b/src/app/api/images/delete/route.ts
@@ -3,7 +3,7 @@ import { objectActions } from '../../../../features/bucket/object-actions';
 
 export async function DELETE(request: Request): Promise<Response> {
   const session = await auth();
-  if (session?.user == null) {
+  if (session?.user == null || session.token == null) {
     return Response.json(
       {
         message: 'Unauthorized',
@@ -25,7 +25,7 @@ export async function DELETE(request: Request): Promise<Response> {
   }
 
   try {
-    const result = await objectActions.deleteObject({ filename });
+    const result = await objectActions.deleteObject({ filename, idToken: session.token });
     if ('message' in result) {
       return Response.json(
         {

--- a/src/app/api/images/route.ts
+++ b/src/app/api/images/route.ts
@@ -9,7 +9,7 @@ const DEFAULT_LIMIT = 20 as const;
 
 export async function GET(request: Request): Promise<NextResponse<GetImagesResponseObject>> {
   const session = await auth();
-  if (session?.user == null) {
+  if (session?.user == null || session.token == null) {
     return NextResponse.json(
       {
         message: 'Unauthorized',
@@ -47,6 +47,7 @@ export async function GET(request: Request): Promise<NextResponse<GetImagesRespo
       limit,
       nextToken,
       secondsToExpire: expiresIn,
+      idToken: session.token,
     });
     if ('message' in result) {
       return NextResponse.json(

--- a/src/app/api/images/upload/route.ts
+++ b/src/app/api/images/upload/route.ts
@@ -16,7 +16,7 @@ const imageData = new WeakMap<Request, Uint8Array>();
  */
 export async function POST(request: Request): Promise<NextResponse<UpsertImagesResponseObject>> {
   const session = await auth();
-  if (session?.user == null) {
+  if (session?.user == null || session.token == null) {
     return NextResponse.json(
       {
         message: 'Unauthorized',
@@ -65,6 +65,7 @@ export async function POST(request: Request): Promise<NextResponse<UpsertImagesR
       filename,
       // Don't consider the absence of a request.
       body: imageData.get(request)!,
+      idToken: session.token,
     });
 
     return NextResponse.json(

--- a/src/features/bucket/image-url-fetcher.test.ts
+++ b/src/features/bucket/image-url-fetcher.test.ts
@@ -16,7 +16,7 @@ jest.unstable_mockModule('@dotenvx/dotenvx', () => ({
 
 // Prevent 'next-auth' execution side-effects.
 jest.unstable_mockModule('./s3-client-instance', () => ({
-  getS3Client: jest.fn<() => Promise<S3Client>>().mockResolvedValue({
+  getS3Client: jest.fn<(idToken: string) => S3Client>().mockReturnValue({
     config: {},
     middlewareStack: jest.fn(),
     destroy: jest.fn(),
@@ -57,7 +57,11 @@ describe('fetchImageUrls', () => {
     });
 
     // Act
-    const result = (await fetchImageUrls({ limit: 3, secondsToExpire: 600 })) as GetImagesSuccessResponseObject;
+    const result = (await fetchImageUrls({
+      limit: 3,
+      secondsToExpire: 600,
+      idToken: 'valid-id-token',
+    })) as GetImagesSuccessResponseObject;
 
     // Assert
     expect(result.urls).toHaveLength(2);

--- a/src/features/bucket/image-url-fetcher.ts
+++ b/src/features/bucket/image-url-fetcher.ts
@@ -12,8 +12,13 @@ const bucketName = dotenvxGet('AWS_S3_BUCKET_NAME');
 async function fetchFileKeys(params: {
   limit: number;
   nextToken?: string;
+  idToken: string;
 }): Promise<{ keys: string[]; nextToken?: string }> {
-  const response = await objectActions.readObjects({ limit: params.limit, startingAfter: params.nextToken });
+  const response = await objectActions.readObjects({
+    limit: params.limit,
+    startingAfter: params.nextToken,
+    idToken: params.idToken,
+  });
   const keys = response.Contents?.flatMap((item) => (item.Key && !item.Key.endsWith('/') ? [item.Key] : [])) ?? [];
 
   return {
@@ -26,12 +31,14 @@ export async function fetchImageUrls(params: {
   limit: number;
   nextToken?: string;
   secondsToExpire: number;
+  idToken: string;
 }): Promise<GetImagesSuccessResponseObject | GetImagesErrorResponseObject> {
-  const client = await getS3Client();
+  const client = getS3Client(params.idToken);
 
   const { keys, nextToken } = await fetchFileKeys({
     limit: params.limit,
     nextToken: params.nextToken,
+    idToken: params.idToken,
   });
 
   const urls = await Promise.all(

--- a/src/features/bucket/object-actions.ts
+++ b/src/features/bucket/object-actions.ts
@@ -11,20 +11,20 @@ import { getS3Client } from './s3-client-instance';
 const bucket = dotenvxGet('AWS_S3_BUCKET_NAME');
 
 export const objectActions = {
-  async upsertObject(params: { filename: string; body: Uint8Array }) {
-    const client = await getS3Client();
+  async upsertObject(params: { filename: string; body: Uint8Array; idToken: string }) {
+    const client = getS3Client(params.idToken);
     return client.send(new PutObjectCommand({ Bucket: bucket, Key: params.filename, Body: params.body }));
   },
 
-  async readObjects(params: { limit: number; startingAfter?: string }) {
-    const client = await getS3Client();
+  async readObjects(params: { limit: number; startingAfter?: string; idToken: string }) {
+    const client = getS3Client(params.idToken);
     return client.send(
       new ListObjectsV2Command({ Bucket: bucket, ContinuationToken: params.startingAfter, MaxKeys: params.limit }),
     );
   },
 
-  async deleteObject(params: { filename: string }) {
-    const client = await getS3Client();
+  async deleteObject(params: { filename: string; idToken: string }) {
+    const client = getS3Client(params.idToken);
     return client.send(new DeleteObjectCommand({ Bucket: bucket, Key: params.filename }));
   },
 };

--- a/src/features/bucket/s3-client-instance.test.ts
+++ b/src/features/bucket/s3-client-instance.test.ts
@@ -6,12 +6,7 @@ jest.unstable_mockModule('@dotenvx/dotenvx', () => ({
   get: jest.fn((key: string) => process.env[key]),
 }));
 
-jest.unstable_mockModule('../auth/auth', () => ({
-  auth: jest.fn(),
-}));
-
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
-import type { Session } from 'next-auth';
 
 describe('S3 Client Instance', () => {
   const ORIGINAL_ENV = process.env;
@@ -30,78 +25,40 @@ describe('S3 Client Instance', () => {
   });
 
   it('should create a new S3 client instance', async () => {
-    // Arrange
-    const { auth } = await import('../auth/auth');
-    const mockAuth = auth as unknown as jest.MockedFunction<() => Promise<Session | null>>;
-
-    mockAuth.mockResolvedValue({
-      user: { email: 'test@example.com' },
-      token: 'valid-id-token',
-      expires: '2099-01-01',
-    });
-
     // Act
     const { getS3Client } = await import('./s3-client-instance');
-    const client = await getS3Client();
+    const client = getS3Client('valid-id-token');
 
     // Assert
     expect(client).toBeDefined();
   });
 
   it('reuses the same client instance for the same ID token', async () => {
-    // Arrange
-    const { auth } = await import('../auth/auth');
-    const mockAuth = auth as unknown as jest.MockedFunction<() => Promise<Session | null>>;
-    mockAuth.mockResolvedValue({
-      user: { email: 'test@example.com' },
-      token: 'valid-id-token',
-      expires: '2099-01-01',
-    });
-
     // Act
     const { getS3Client } = await import('./s3-client-instance');
-    const first = await getS3Client();
-    const second = await getS3Client();
+    const first = getS3Client('valid-id-token');
+    const second = getS3Client('valid-id-token');
 
     // Assert
     expect(second).toBe(first);
   });
 
   it('creates a new client instance when the ID token changes', async () => {
-    // Arrange
-    const { auth } = await import('../auth/auth');
-    const mockAuth = auth as unknown as jest.MockedFunction<() => Promise<Session | null>>;
-    mockAuth.mockResolvedValueOnce({
-      user: { email: 'test@example.com' },
-      token: 'first-token',
-      expires: '2099-01-01',
-    });
-    mockAuth.mockResolvedValueOnce({
-      user: { email: 'test@example.com' },
-      token: 'second-token',
-      expires: '2099-01-01',
-    });
-
     // Act
     const { getS3Client } = await import('./s3-client-instance');
-    const first = await getS3Client();
-    const second = await getS3Client();
+    const first = getS3Client('first-token');
+    const second = getS3Client('second-token');
 
     // Assert
     expect(second).not.toBe(first);
   });
 
   it('should throw error if idToken is missing', async () => {
-    // Arrange
-    const { auth } = await import('../auth/auth');
-    const mockAuth = auth as unknown as jest.MockedFunction<() => Promise<Session | null>>;
-    mockAuth.mockResolvedValue(null);
-
     // Act
     const { getS3Client } = await import('./s3-client-instance');
 
     // Assert
-    await expect(getS3Client()).rejects.toThrow('No authenticated session or ID token available');
+    expect(() => getS3Client('')).toThrow('No authenticated session or ID token available');
   });
 
   it('throws at module load when AUTH_COGNITO_ISSUER is missing', async () => {

--- a/src/features/bucket/s3-client-instance.ts
+++ b/src/features/bucket/s3-client-instance.ts
@@ -2,8 +2,6 @@ import { S3Client } from '@aws-sdk/client-s3';
 import { fromCognitoIdentityPool } from '@aws-sdk/credential-providers';
 import { get as dotenvxGet } from '@dotenvx/dotenvx';
 
-import { auth } from '../auth/auth';
-
 // Execute the function at the module scope to avoid multiple decryptions
 const issuer = dotenvxGet('AUTH_COGNITO_ISSUER');
 const userPoolId = issuer?.split('/').pop();
@@ -30,14 +28,14 @@ const providerName = `cognito-idp.${region}.amazonaws.com/${userPoolId}`;
 // A different token just rebuilds, which matches the previous unconditional behavior.
 let cachedClient: { token: string; client: S3Client } | null = null;
 
-export async function getS3Client(): Promise<S3Client> {
-  const session = await auth();
-
-  if (session == null || session.token == null) {
+// The ID token is passed in rather than resolved here so the caller can run auth() once per
+// request instead of once per getS3Client call.
+export function getS3Client(idToken: string): S3Client {
+  if (idToken === '') {
     throw new Error('No authenticated session or ID token available');
   }
 
-  if (cachedClient != null && cachedClient.token === session.token) {
+  if (cachedClient != null && cachedClient.token === idToken) {
     return cachedClient.client;
   }
 
@@ -47,12 +45,12 @@ export async function getS3Client(): Promise<S3Client> {
       identityPoolId,
       clientConfig: { region },
       logins: {
-        [providerName]: session.token,
+        [providerName]: idToken,
       },
     }),
   });
 
-  cachedClient = { token: session.token, client };
+  cachedClient = { token: idToken, client };
 
   return client;
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "regions": ["hnd1"]
+}


### PR DESCRIPTION
## Summary

Follow-up to the S3 client credential cache. After that change, a warm production instance dropped `/api/images` from about 2.4s to roughly 374ms, but two costs remained that the cache did not touch. This PR removes both.

`auth()` ran three times per request. The route handler called it once, and `getS3Client` called it again on each of its two invocations (presigning and listing). Each call decodes the session JWE and runs the next-auth callbacks. `getS3Client` no longer resolves the session itself. It takes the ID token as an argument, so the handler resolves the session once and threads the token down through `fetchImageUrls` and `objectActions`. With the token passed in, `getS3Client` has nothing to await and is now synchronous.

The production function also ran in `iad1` (Washington) while Cognito and S3 live in `ap-northeast-1` (Tokyo). Every credential exchange and token refresh crossed the Pacific, which dominated cold starts and any request that refreshed the token. A `vercel.json` `regions` entry pins the serverless functions to `hnd1` (Tokyo) to sit next to those services. The route segment `preferredRegion` is not used because on Vercel it applies only to Edge runtime routes, and these functions need the Node.js runtime for the AWS SDK and next-auth.

The 401 guard in each route now also rejects a session without an ID token. Previously that case reached `getS3Client` and surfaced as a 500, so this reports the missing credential as an auth failure instead.

## Test plan

- [x] `npx jest` (8 tests pass). `getS3Client` tests now exercise the synchronous token-argument form, including reuse and rebuild on token change.
- [x] `npx tsc --noEmit`
- [x] `npx eslint` on the changed files
- [ ] After deploy, confirm the function region is `hnd1` via `x-vercel-id`, and re-measure warm and cold `/api/images` timing.
